### PR TITLE
Handle text stored in iMessage attributed body

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,15 @@ Unix timestamps and then formatted as ISO strings in your local timezone.
 For group chats, the `display_name` field contains the chat's name when available, and all 
 participants are listed in the `participants` field.
 
-Attachments are referenced by relative paths which are typically within the 
+Attachments are referenced by relative paths which are typically within the
 `~/Library/Messages/Attachments/` directory.
+
+### Rich Text Messages
+
+Some messages include rich formatting or special effects. In these cases the
+plain text may be stored in the `attributedBody` column rather than `text`.
+This project now decompresses and unarchives that data to extract the message
+string when present.
 
 ## Common Issues
 

--- a/tests/test_attributed_body.py
+++ b/tests/test_attributed_body.py
@@ -1,0 +1,29 @@
+import gzip
+import plistlib
+
+import pytest
+
+from imessage_extractor.database import IMessageDatabase
+
+
+@pytest.fixture
+def archived_message():
+    """Return a message row with text stored in ``attributedBody``."""
+    text = "Hello from attributed body"
+    plist = {
+        "$version": 100000,
+        "$archiver": "NSKeyedArchiver",
+        "$objects": [
+            "$null",
+            {"NS.string": text},
+        ],
+        "$top": {"root": 1},
+    }
+    data = plistlib.dumps(plist, fmt=plistlib.FMT_BINARY)
+    return {"text": None, "attributedBody": gzip.compress(data), "expected": text}
+
+
+def test_extract_text_from_attributed_body(archived_message):
+    db = IMessageDatabase(db_path=":memory:")
+    result = db._extract_text_from_attributed_body(archived_message["attributedBody"])
+    assert result == archived_message["expected"]


### PR DESCRIPTION
## Summary
- Parse gzip-compressed `attributedBody` blobs as binary property lists and extract embedded strings
- Document rich-text messages and their `attributedBody` storage
- Add unit test for archived text extraction

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c35e8eefb08320aaedf189d2ca5acf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved support for rich text messages by extracting readable text from attributed message content.

- Bug Fixes
  - Fixed cases where rich text messages could appear empty or garbled by reliably parsing their content.

- Documentation
  - Added a “Rich Text Messages” section explaining how such messages are handled.
  - Clarified attachment path formatting.
  - Expanded “Common Issues” with notes on empty text fields and guidance for iCloud users to copy all chat database files.

- Tests
  - Added unit tests to validate rich text message extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->