### PR TITLE
chore: support Python 3.9+

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Parse and Extract iMessage Conversations"
 readme = "README.md"
 authors = [{name = "Scott Macdonald"}]
 license = "Apache-2.0"
-requires-python = ">=3.13"
+requires-python = ">=3.9"
 classifiers = []
 dependencies = [
     "click",


### PR DESCRIPTION
## Summary
- broaden supported Python versions to 3.9+
- run CI on Python 3.11

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3760512e08320804025746c7cc26f