### PR TITLE
Expose package version and hook it into the CLI

### DIFF
--- a/imessage_extractor/__init__.py
+++ b/imessage_extractor/__init__.py
@@ -1,0 +1,9 @@
+"""Core package initialization for :mod:`imessage_extractor`.
+
+This module exposes public package metadata such as the version number.
+"""
+
+__all__ = ["__version__"]
+
+__version__ = "0.3"
+

--- a/imessage_extractor/cli.py
+++ b/imessage_extractor/cli.py
@@ -1,5 +1,6 @@
 import click
 
+from . import __version__
 from .commands import (
     export_chat_command,
     export_all_command,
@@ -8,7 +9,7 @@ from .commands import (
 
 
 @click.group()
-@click.version_option()
+@click.version_option(version=__version__)
 def cli():
     """Parse and Extract iMessage Conversations.
 


### PR DESCRIPTION
## Summary
- add package docstring, __all__, and __version__ to `imessage_extractor`
- wire CLI `--version` flag to use the package's `__version__`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3760a57f083209c9fd4b4ed937089