### PR TITLE
test: add validation and export tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ To run the tests:
 python -m pytest
 ```
 
+The test suite covers input validation helpers, database export functions, and
+parser utilities (such as URL and mention extraction).
+
 ## How It Works
 
 This tool directly reads your iMessage database file (chat.db) which is maintained by macOS. 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,100 @@
+import os
+import sqlite3
+import sys
+import pytest
+
+# Ensure package root is importable when running tests directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from imessage_extractor.database import IMessageDatabase
+
+
+@pytest.fixture
+def mock_imessage_db(monkeypatch):
+    """Create an in-memory iMessage database with sample data."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+
+    # Create tables
+    cur.executescript(
+        """
+        CREATE TABLE chat (
+            rowid INTEGER PRIMARY KEY,
+            guid TEXT,
+            chat_identifier TEXT,
+            display_name TEXT
+        );
+        CREATE TABLE handle (
+            rowid INTEGER PRIMARY KEY,
+            id TEXT
+        );
+        CREATE TABLE chat_handle_join (
+            chat_id INTEGER,
+            handle_id INTEGER
+        );
+        CREATE TABLE message (
+            rowid INTEGER PRIMARY KEY,
+            text TEXT,
+            attributedBody BLOB,
+            is_from_me INTEGER,
+            handle_id INTEGER,
+            service TEXT,
+            date INTEGER,
+            date_read INTEGER,
+            date_delivered INTEGER,
+            associated_message_guid TEXT,
+            thread_originator_guid TEXT,
+            item_type INTEGER
+        );
+        CREATE TABLE chat_message_join (
+            chat_id INTEGER,
+            message_id INTEGER
+        );
+        CREATE TABLE attachment (
+            rowid INTEGER PRIMARY KEY,
+            filename TEXT,
+            transfer_name TEXT,
+            mime_type TEXT
+        );
+        CREATE TABLE message_attachment_join (
+            message_id INTEGER,
+            attachment_id INTEGER
+        );
+        """
+    )
+
+    # Insert sample data
+    cur.executescript(
+        """
+        INSERT INTO chat(rowid, guid, chat_identifier, display_name)
+        VALUES (1, 'chat-guid', 'chat-identifier', 'Sample Chat');
+
+        INSERT INTO handle(rowid, id)
+        VALUES (1, 'user@example.com');
+
+        INSERT INTO chat_handle_join(chat_id, handle_id)
+        VALUES (1, 1);
+
+        INSERT INTO message(rowid, text, attributedBody, is_from_me, handle_id, service, date,
+                            date_read, date_delivered, associated_message_guid, thread_originator_guid, item_type)
+        VALUES (1, 'Hello', NULL, 1, 1, 'iMessage', 0, NULL, NULL, NULL, NULL, 0);
+
+        INSERT INTO chat_message_join(chat_id, message_id)
+        VALUES (1, 1);
+
+        INSERT INTO attachment(rowid, filename, transfer_name, mime_type)
+        VALUES (1, '/path/to/file.txt', 'file.txt', 'text/plain');
+
+        INSERT INTO message_attachment_join(message_id, attachment_id)
+        VALUES (1, 1);
+        """
+    )
+    conn.commit()
+
+    db = IMessageDatabase(db_path=":memory:")
+    monkeypatch.setattr(IMessageDatabase, "get_connection", lambda self: conn)
+
+    yield db
+
+    conn.close()

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,48 @@
+"""Tests for database export functions."""
+
+import csv
+import json
+
+
+def test_export_chat_to_csv(mock_imessage_db, tmp_path):
+    """export_chat_to_csv should write chat messages to a CSV file."""
+    output = tmp_path / "chat.csv"
+    mock_imessage_db.export_chat_to_csv(1, str(output))
+
+    with output.open() as f:
+        rows = list(csv.reader(f))
+
+    assert rows[0] == [
+        "message_id",
+        "timestamp_local_iso",
+        "from_me",
+        "sender_identifier",
+        "text",
+        "service",
+        "attachment_name",
+        "attachment_mime",
+        "attachment_path",
+    ]
+    assert rows[1][0] == "1"
+    assert rows[1][1] == "2001-01-01T00:00:00+00:00"
+    assert rows[1][3] == "user@example.com"
+    assert rows[1][4] == "Hello"
+    assert rows[1][6] == "file.txt"
+
+
+def test_export_all_chats_to_json(mock_imessage_db, tmp_path):
+    """export_all_chats_to_json should write all chats to a JSON file."""
+    output = tmp_path / "all.json"
+    mock_imessage_db.export_all_chats_to_json(str(output))
+
+    data = json.loads(output.read_text())
+    assert isinstance(data, list)
+    assert len(data) == 1
+    chat = data[0]
+    assert chat["chat_guid"] == "chat-guid"
+    assert chat["participants"] == ["user@example.com"]
+    assert len(chat["messages"]) == 1
+    msg = chat["messages"][0]
+    assert msg["id"] == 1
+    assert msg["timestamp"] == "2001-01-01T00:00:00+00:00"
+    assert msg["attachments"][0]["name"] == "file.txt"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,20 @@
+"""Tests for parser utility functions."""
+
+from imessage_extractor.parsers import TextParser
+
+
+def test_extract_urls_from_text():
+    """URLs should be extracted from text content."""
+    text = "See https://example.com and http://test.com/path?query=1"
+    urls = TextParser.extract_urls_from_text(text)
+    assert urls == [
+        "https://example.com",
+        "http://test.com/path?query=1",
+    ]
+
+
+def test_extract_mentions_from_text():
+    """Mentions should be extracted from text content."""
+    text = "Hello @alice and @bob!"
+    mentions = TextParser.extract_mentions_from_text(text)
+    assert mentions == ["alice", "bob"]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,85 @@
+"""Tests for validator utility functions."""
+
+import os
+import pytest
+
+from imessage_extractor.validators import (
+    validate_chat_candidates,
+    validate_user_choice,
+    validate_file_path,
+    validate_participant_identifier,
+    validate_database_row,
+    validate_output_format,
+    validate_positive_integer,
+)
+from imessage_extractor.exceptions import (
+    MissingRequiredFieldError,
+    InvalidChoiceError,
+    InvalidDataFormatError,
+)
+from imessage_extractor.constants import REQUIRED_CHAT_KEYS
+
+
+def test_validate_chat_candidates_valid():
+    """Ensure validate_chat_candidates returns True for valid input."""
+    candidates = [{key: 1 for key in REQUIRED_CHAT_KEYS}]
+    assert validate_chat_candidates(candidates) is True
+
+
+def test_validate_chat_candidates_missing():
+    """Missing required keys should raise MissingRequiredFieldError."""
+    candidates = [{"rowid": 1, "display_name": "name", "chat_identifier": "id"}]
+    with pytest.raises(MissingRequiredFieldError):
+        validate_chat_candidates(candidates)
+
+
+def test_validate_user_choice():
+    """validate_user_choice converts to zero-based index and enforces bounds."""
+    assert validate_user_choice(1, 3) == 0
+    with pytest.raises(InvalidChoiceError):
+        validate_user_choice(0, 3)
+    with pytest.raises(InvalidChoiceError):
+        validate_user_choice(4, 3)
+
+
+def test_validate_file_path(tmp_path):
+    """validate_file_path expands paths and checks existence."""
+    file = tmp_path / "file.txt"
+    file.write_text("data")
+    assert validate_file_path(str(file), must_exist=True) == str(file)
+    with pytest.raises(FileNotFoundError):
+        validate_file_path(str(file.with_name("missing.txt")), must_exist=True)
+    with pytest.raises(InvalidDataFormatError):
+        validate_file_path("", must_exist=False)
+
+
+def test_validate_participant_identifier():
+    """Participant identifiers must contain alphanumeric characters."""
+    assert validate_participant_identifier("user@example.com") == "user@example.com"
+    with pytest.raises(InvalidDataFormatError):
+        validate_participant_identifier("@@@")
+
+
+def test_validate_database_row():
+    """validate_database_row checks for presence of required keys."""
+    row = {"id": 1, "name": "Alice"}
+    assert validate_database_row(row, ["id", "name"]) == row
+    with pytest.raises(MissingRequiredFieldError):
+        validate_database_row({"id": 1}, ["id", "name"])
+
+
+def test_validate_output_format():
+    """validate_output_format ensures file extension is allowed."""
+    path = validate_output_format("output.csv", ["csv", "json"])
+    assert path.endswith("output.csv")
+    with pytest.raises(InvalidDataFormatError):
+        validate_output_format("output.txt", ["csv", "json"])
+
+
+def test_validate_positive_integer():
+    """validate_positive_integer enforces positive integers."""
+    assert validate_positive_integer("5", "test") == 5
+    with pytest.raises(InvalidDataFormatError):
+        validate_positive_integer("-1", "test")
+    with pytest.raises(InvalidDataFormatError):
+        validate_positive_integer("abc", "test")


### PR DESCRIPTION
## Summary
- add tests for validators
- test CSV and JSON export functions using an in-memory database
- test URL and mention extraction utilities
- document test coverage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c37621a8ec832099f64eb788e9437c