### PR TITLE
Handle built-in permission and missing file errors gracefully

### DIFF
--- a/imessage_extractor/constants.py
+++ b/imessage_extractor/constants.py
@@ -108,6 +108,13 @@ To resolve this issue:
 5. Try running the command again
 """
 
+GUIDANCE_FILE_NOT_FOUND = """
+To resolve this issue:
+1. Verify the file path is correct
+2. Ensure the file exists and you have access to it
+3. Expand any '~' or environment variables to full paths
+"""
+
 # Validation Constants
 REQUIRED_CHAT_KEYS = ["rowid", "display_name", "chat_identifier", "participants"]
 MAX_CHOICE_INDEX = 1000  # Reasonable upper bound for user selection

--- a/imessage_extractor/error_handlers.py
+++ b/imessage_extractor/error_handlers.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from typing import Optional
 
-from .constants import GUIDANCE_PERMISSION_ERROR
+from .constants import GUIDANCE_FILE_NOT_FOUND, GUIDANCE_PERMISSION_ERROR
 from .exceptions import (
     DatabaseError,
     DatabasePermissionError,
@@ -51,6 +51,22 @@ def handle_database_error(e: DatabaseError, logger: logging.Logger) -> int:
     """
     logger.error(f"Database error: {e}")
     print(f"Database error: {e}", file=sys.stderr)
+    return 1
+
+
+def handle_file_not_found_error(e: FileNotFoundError, logger: logging.Logger) -> int:
+    """Handle file not found errors with helpful guidance.
+
+    Args:
+        e: The file not found error exception
+        logger: Logger instance for verbose output
+
+    Returns:
+        Exit code 1
+    """
+    logger.error(f"File not found: {e}")
+    print(f"Error: {e}", file=sys.stderr)
+    print(GUIDANCE_FILE_NOT_FOUND, file=sys.stderr)
     return 1
 
 
@@ -143,11 +159,13 @@ def handle_error_with_fallback(e: Exception, logger: logging.Logger, fallback_me
     # Map exception types to their handlers
     error_handlers = {
         DatabasePermissionError: handle_permission_error,
+        PermissionError: handle_permission_error,
         DatabaseLockedError: handle_database_error,
         DatabaseNotFoundError: handle_database_error,
         DatabaseError: handle_database_error,
         FileWriteError: handle_file_operation_error,
         FileReadError: handle_file_operation_error,
+        FileNotFoundError: handle_file_not_found_error,
         FileOperationError: handle_file_operation_error,
         MissingRequiredFieldError: handle_validation_error,
         InvalidChoiceError: handle_validation_error,


### PR DESCRIPTION
## Summary
- add guidance constant and handler for missing file errors
- handle built-in `PermissionError` and `FileNotFoundError` through error mapping

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c37627e6fc832088ef21f133a804c3